### PR TITLE
Restructure polinrider-scan skill to follow skill-creator spec

### DIFF
--- a/skills/polinrider-scan/SKILL.md
+++ b/skills/polinrider-scan/SKILL.md
@@ -7,6 +7,13 @@ description: Scan for the PolinRider DPRK/Lazarus supply-chain malware (March–
 
 Perform a comprehensive security scan for the **PolinRider** malware (DPRK Lazarus group supply-chain attack, March–April 2026). This malware targets JavaScript/Node.js developers, steals cryptocurrency wallets, and propagates through git repositories via force-push.
 
+The scan has **two steps**:
+
+1. **Phase 0** — run the official [`polinrider-scanner.sh`](https://github.com/OpenSourceMalware/PolinRider/blob/main/polinrider-scanner.sh) from OpenSourceMalware (the authoritative, regularly updated IOC scanner).
+2. **Phases 1–10** — AI-driven checks that extend the official scanner: caching/persistence edge cases, obfuscation heuristics, novel variant detection, and automated remediation.
+
+Both steps must run. The AI phases are not a replacement for the upstream scanner — they complement it.
+
 ## Scope detection (do this FIRST)
 
 Determine install scope by checking where this skill lives:
@@ -18,6 +25,26 @@ Determine install scope by checking where this skill lives:
 State the detected scope and the resolved `$SCAN_ROOT` in one sentence before starting, then execute every phase below that applies to the scope. Do NOT ask for confirmation — execute automatically. Report findings at the end in a structured table. If you find active infections, remediate them immediately.
 
 In the commands below, `$SCAN_ROOT` means: the cwd in local scope, or `$HOME` in global scope (or the explicit path the user provided). Persistence checks in Phase 8 always run against `$HOME` regardless of `$SCAN_ROOT`.
+
+## Phase 0: Run the official OSM scanner FIRST
+
+Before doing any AI-driven analysis, run the upstream shell scanner from [OpenSourceMalware/PolinRider](https://github.com/OpenSourceMalware/PolinRider). It's the authoritative source of IOCs and is updated when new variants surface.
+
+```bash
+# Download to a temp file, inspect, then run
+curl -fsSL -o /tmp/polinrider-scanner.sh \
+  https://raw.githubusercontent.com/OpenSourceMalware/PolinRider/main/polinrider-scanner.sh
+
+# Optional but recommended — skim the script before executing
+head -50 /tmp/polinrider-scanner.sh
+
+# Run against $SCAN_ROOT
+bash /tmp/polinrider-scanner.sh "$SCAN_ROOT"
+```
+
+Capture the scanner's output. Include its findings in the final report under a dedicated "Official scanner (OSM)" section. Then continue with Phase 1 onwards — the AI phases catch variants, stale caches, and edge cases the upstream scanner may not cover yet.
+
+If `curl` fails or the user is offline, note that Phase 0 was skipped and proceed with Phases 1–10.
 
 ## Phase 1: Active Threat Neutralization
 
@@ -453,6 +480,9 @@ Present results as:
 
 ```
 ## Scan Results (scope: LOCAL | GLOBAL)
+
+### Official scanner (OSM polinrider-scanner.sh)
+<exit code, summary of findings, or "skipped — offline">
 
 ### Active Threats
 | Type | Location | Status |

--- a/skills/polinrider-scan/SKILL.md
+++ b/skills/polinrider-scan/SKILL.md
@@ -1,509 +1,114 @@
 ---
 name: polinrider-scan
-description: Scan for the PolinRider DPRK/Lazarus supply-chain malware (March–April 2026). Checks running processes, config files, build caches, VS Code droppers, npm packages, git hooks, system persistence, and GitHub repos. Scope auto-adapts: project-only when installed at .claude/skills/, filesystem-wide when installed at ~/.claude/skills/.
+description: Scan for the PolinRider DPRK/Lazarus supply-chain malware (March–April 2026 campaign). Use when the user asks to check for PolinRider, audit a project or machine for the DPRK npm/VS Code supply-chain compromise, or verify that postcss/next/webpack/tailwind config files, build caches, VS Code tasks.json droppers, or git hooks are clean. Triggers on phrases like "scan for PolinRider", "check for the DPRK supply-chain malware", "audit my repos for the config.bat/temp_auto_push stuff", or any reference to the IOCs in references/iocs.md. Run this proactively if the user reports unexplained `node -e` processes, mysterious `createRequire` imports in config files, unknown `tailwindcss-style-animate`-style packages, or unexpected `.vscode/tasks.json` with `folderOpen`.
 ---
 
 # PolinRider Malware Scan
 
-Perform a comprehensive security scan for the **PolinRider** malware (DPRK Lazarus group supply-chain attack, March–April 2026). This malware targets JavaScript/Node.js developers, steals cryptocurrency wallets, and propagates through git repositories via force-push.
+This skill performs a two-step security scan for the **PolinRider** malware — a DPRK/Lazarus supply-chain attack (March–April 2026) that targets JavaScript/Node.js developers, steals cryptocurrency wallets, and propagates via git force-push.
 
-The scan has **two steps**:
+The heavy lifting lives in [`scripts/scan.sh`](scripts/scan.sh), which:
 
-1. **Phase 0** — run the official [`polinrider-scanner.sh`](https://github.com/OpenSourceMalware/PolinRider/blob/main/polinrider-scanner.sh) from OpenSourceMalware (the authoritative, regularly updated IOC scanner).
-2. **Phases 1–10** — AI-driven checks that extend the official scanner: caching/persistence edge cases, obfuscation heuristics, novel variant detection, and automated remediation.
+1. Downloads and runs the official [`polinrider-scanner.sh`](https://github.com/OpenSourceMalware/PolinRider/blob/main/polinrider-scanner.sh) from OpenSourceMalware — the authoritative, regularly updated IOC scanner.
+2. Runs extended checks that complement the upstream scanner: build-cache persistence, VS Code droppers, fake binary payloads, git/husky hook injection, obfuscation heuristics, system persistence, and (in global scope) GitHub repository search.
 
-Both steps must run. The AI phases are not a replacement for the upstream scanner — they complement it.
+Your job is to decide the scope, invoke the script, interpret the structured output, and drive remediation when infections are found.
 
-## Scope detection (do this FIRST)
+## Step 1: Decide the scope
 
-Determine install scope by checking where this skill lives:
+Determine scope in this order:
 
-- If this file exists at `$CLAUDE_PROJECT_DIR/.claude/skills/polinrider-scan/SKILL.md` or `./.claude/skills/polinrider-scan/SKILL.md` → **LOCAL scope**. Scan root = current working directory only. Skip filesystem-wide `find ~/` commands. Skip Phase 8 (system persistence). Skip Phase 9 (GitHub repos) unless user explicitly asks.
-- If this file exists at `~/.claude/skills/polinrider-scan/SKILL.md` (user-global) → **GLOBAL scope**. Scan root = `$HOME`. Run all phases including system persistence and GitHub repo scan.
-- If the user passed an explicit argument, honor that instead. Accepted forms: `local`, `global`, or an absolute path (`/abs/path`) or `~`-prefixed path to use as the scan root.
+1. If the user passed an explicit argument, honor it:
+   - `local` → scope = local, scan_root = cwd
+   - `global` → scope = global, scan_root = `$HOME`
+   - An absolute or `~`-prefixed path → scope = local, scan_root = that path
+2. Otherwise, detect install location:
+   - This skill resolved from `$CLAUDE_PROJECT_DIR/.claude/skills/polinrider-scan/` or `./.claude/skills/polinrider-scan/` → **local**. scan_root = `$PWD`. Skips `PERSISTENCE` and `GITHUB_SCAN` sections.
+   - This skill resolved from `~/.claude/skills/polinrider-scan/` → **global**. scan_root = `$HOME`. Runs everything.
 
-State the detected scope and the resolved `$SCAN_ROOT` in one sentence before starting, then execute every phase below that applies to the scope. Do NOT ask for confirmation — execute automatically. Report findings at the end in a structured table. If you find active infections, remediate them immediately.
+State the resolved scope and `scan_root` in one sentence before running the script.
 
-In the commands below, `$SCAN_ROOT` means: the cwd in local scope, or `$HOME` in global scope (or the explicit path the user provided). Persistence checks in Phase 8 always run against `$HOME` regardless of `$SCAN_ROOT`.
-
-## Phase 0: Run the official OSM scanner FIRST
-
-Before doing any AI-driven analysis, run the upstream shell scanner from [OpenSourceMalware/PolinRider](https://github.com/OpenSourceMalware/PolinRider). It's the authoritative source of IOCs and is updated when new variants surface.
-
-```bash
-# Download to a temp file, inspect, then run
-curl -fsSL -o /tmp/polinrider-scanner.sh \
-  https://raw.githubusercontent.com/OpenSourceMalware/PolinRider/main/polinrider-scanner.sh
-
-# Optional but recommended — skim the script before executing
-head -50 /tmp/polinrider-scanner.sh
-
-# Run against $SCAN_ROOT
-bash /tmp/polinrider-scanner.sh "$SCAN_ROOT"
-```
-
-Capture the scanner's output. Include its findings in the final report under a dedicated "Official scanner (OSM)" section. Then continue with Phase 1 onwards — the AI phases catch variants, stale caches, and edge cases the upstream scanner may not cover yet.
-
-If `curl` fails or the user is offline, note that Phase 0 was skipped and proceed with Phases 1–10.
-
-## Phase 1: Active Threat Neutralization
-
-**Check for running malware processes FIRST — kill before it can spread.** (Run this phase in both scopes — a running infection affects the whole machine.)
-
-### 1.1 Malicious Node Processes
-
-Search for detached `node -e` processes (the malware spawns these with `stdio: 'ignore'`, `detached: true`):
-
-```
-ps aux | grep "node -e" | grep -v grep
-```
-
-Check for ANY node process whose parent is PID 1 (launchd/init) — this means the parent died and the process was reparented, a hallmark of PolinRider:
-
-```
-ps -eo pid,ppid,comm,args | awk '$2 == 1 && /node/ {print}'
-```
-
-Look for node processes with suspicious arguments containing any of these: `global['!']`, `global['_V']`, `_$_1e42`, `MDy`, `rmcej`, `2857687`, `1111436`, `spawn`, `child_process`, `eval`:
-
-```
-ps aux | grep node | grep -v grep
-```
-
-**If found: `kill -9 <PID>` immediately.**
-
-### 1.2 Network Connections to C2
-
-Check for active connections to known command-and-control endpoints:
-
-```
-lsof -i -n -P | grep -i "node" | grep -v localhost
-```
-
-Known C2 domains (block these in your firewall/hosts file):
-- `260120.vercel.app`
-- `default-configuration.vercel.app`
-- `vscode-settings-bootstrap.vercel.app`
-- `vscode-settings-config.vercel.app`
-- `vscode-bootstrapper.vercel.app`
-- `vscode-load-config.vercel.app`
-- `api.trongrid.io` (blockchain dead-drop)
-- `fullnode.mainnet.aptoslabs.com` (blockchain dead-drop)
-- `bsc-dataseed.binance.org` (blockchain dead-drop)
-- `bsc-rpc.publicnode.com` (blockchain dead-drop)
-
-## Phase 2: Payload Signature Scan
-
-Search `$SCAN_ROOT` (excluding `node_modules` and `.git`) for both known variants.
-
-### 2.1 Original Variant Signatures
-
-| Signature | Description |
-|---|---|
-| `rmcej%otb%` | Obfuscation marker |
-| `_$_1e42` | Decoder function name |
-| `2857687` | Shuffle seed (layer 1) |
-| `2667686` | Shuffle seed (layer 2) |
-| `global['!']` | Global injection marker |
-| `global['r'] = require` | Require hijack |
-| `global['m'] = module` | Module hijack |
-
-### 2.2 Rotated Variant Signatures (April 2026)
-
-| Signature | Description |
-|---|---|
-| `Cot%3t=shtP` | Rotated obfuscation marker |
-| `function MDy` or `var MDy=` | Rotated decoder function |
-| `1111436` | Rotated shuffle seed (layer 1) |
-| `3896884` | Rotated shuffle seed (layer 2) |
-| `global['_V']` | Rotated global injection (tags `8-st1` through `8-st59`) |
-
-### 2.3 XOR Keys and Blockchain Addresses
-
-| Signature | Description |
-|---|---|
-| `2[gWfGj;<:-93Z^C` | XOR decryption key (primary) |
-| `m6:tTh^D)cBz?NM]` | XOR decryption key (secondary) |
-| `TMfKQEd7TJJa5xNZJZ2Lep838vrzrs7mAP` | TRON C2 address |
-| `TXfxHUet9pJVU1BgVkBAbrES4YUc1nGzcG` | TRON C2 address (secondary) |
-| `0xbe037400670fbf1c32364f762975908dc43eeb38759263e7dfcdabc76380811e` | Aptos C2 address |
-| `0x3f0e5781d0855fb460661ac63257376db1941b2bb522499e4757ecb3ebd5dce3` | Aptos C2 address (secondary) |
-
-### 2.4 Scan Commands
-
-Scan all source files in `$SCAN_ROOT` for ALL signatures above. Use `grep -rl` with `--include` for `*.js`, `*.mjs`, `*.cjs`, `*.json`, `*.ts`, `*.tsx`, `*.bat`, `*.sh`, `*.woff2`, `*.woff`, `*.ttf`. Exclude `node_modules/`, `.git/`, `.next/`, `dist/`, `build/`. Also exclude any file named `polinrider-scanner` or `polinrider-scan` (legitimate scanner files referencing these patterns).
-
-## Phase 3: Config File Infection Scan
-
-PolinRider appends obfuscated JavaScript after hundreds of whitespace characters on the last line of config files. The file looks normal in editors because the payload is hidden off-screen.
-
-### 3.1 Target Config Files
-
-Scan ALL of these file patterns within `$SCAN_ROOT`:
-- `postcss.config.*` (js/mjs/cjs/ts)
-- `tailwind.config.*`
-- `eslint.config.*`
-- `next.config.*`
-- `vite.config.*`
-- `webpack.config.*`
-- `astro.config.*`
-- `gridsome.config.*`
-- `vue.config.*`
-- `rollup.config.*`
-- `babel.config.*`
-- `truffle.js`
-- `.eslintrc.*`
-- `App.js`, `app.js`, `index.js` (in project roots only)
-
-### 3.2 Detection Methods
-
-For each config file found:
-
-1. **Long line check**: Any line > 200 characters is suspicious (legitimate config files rarely exceed this). Use `awk '{ if(length > max) max=length } END { print max+0 }'`.
-
-2. **Trailing whitespace bomb**: Check for 50+ consecutive spaces: `grep -P '\s{50,}'` (the payload hides after spaces on the export line).
-
-3. **`createRequire` residue**: The malware injects `import { createRequire } from 'module'` (or `from 'node:module'`) into ESM config files. If the file is a simple config (postcss, tailwind, etc.) and contains `createRequire`, it's malware residue. Remove it.
-
-4. **Direct signature check**: `grep` each file for `global['!']`, `global['_V']`, `_$_1e42`, `MDy`, `rmcej`.
-
-## Phase 4: Build Cache Infection (CRITICAL — Often Missed)
-
-**This is the #1 reason the malware re-appears after cleanup.** Build tools (Next.js Turbopack, Webpack, Vite) cache compiled versions of config files. Even after cleaning the source, the cached infected version keeps executing.
-
-### 4.1 Next.js / Turbopack Cache
+## Step 2: Run the scanner
 
 ```bash
-find "$SCAN_ROOT" -name ".next" -type d -not -path "*/node_modules/*" | while read d; do
-  hit=$(grep -rl "global\['!'\]\|_\$_1e42\|rmcej\|global\['_V'\]\|MDy" "$d/" 2>/dev/null | head -1)
-  if [ -n "$hit" ]; then
-    echo "INFECTED CACHE: $hit"
-  fi
-done
+bash "$(dirname "$0")/scripts/scan.sh" <scope> <scan_root>
 ```
 
-**The payload specifically persists in Turbopack SST files** (`.next/dev/cache/turbopack/*.sst`) — these are binary files that survive source file cleanup.
+In practice, invoke it with the absolute path to `scan.sh` inside the installed skill directory. The script writes a structured report to stdout, organized as `== SECTION ==` blocks. Sections include:
 
-**Remediation**: Delete the entire `.next` directory. Kill any running `next dev` process FIRST or it will recreate the cache immediately.
+- `META` — scope, host, timestamps
+- `OSM_SCANNER` — output of the official scanner (Step 1)
+- `PROCESSES`, `NETWORK_C2` — active threats
+- `SIGNATURES`, `CONFIG_FILES`, `BUILD_CACHES` — payload detection
+- `VSCODE_DROPPERS`, `FAKE_BINARIES` — VS Code-based droppers
+- `PROPAGATION_ARTIFACTS`, `NPM_PACKAGES`, `OBFUSCATION_HEURISTICS`
+- `PERSISTENCE`, `GITHUB_SCAN` — global-scope only
 
-### 4.2 Other Build Caches
+Capture the output. The script always exits 0 — the presence or absence of findings is encoded in the text of each section.
 
-Also scan:
-- `.cache/` directories (Webpack, Babel)
-- `.turbo/` directories (Turborepo)
-- `.parcel-cache/` directories
-- `.vite/` directories
-- `dist/`, `build/` directories (may contain compiled infected output)
+## Step 3: Interpret the output
 
-## Phase 5: VS Code Dropper Detection
+For each section, check whether findings are real or benign:
 
-PolinRider uses VS Code's `runOn: folderOpen` feature to silently execute malware when a folder is opened in the editor.
+- **Signature hits on the skill itself, the IOC reference file, or known scanners** (`polinrider-scanner*`, `scan.sh`, `iocs.md`, OSM repo) are benign — these files deliberately reference the patterns.
+- **`CONFIG_FILES` `SUSPECT` entries** — open the file. If the long line is a minified bundle (legitimate for some build artifacts) it's a false positive. If it's a plain config file with `createRequire` + trailing whitespace + high max-line length, it's infected.
+- **`BUILD_CACHES` `INFECTED` entries** — always real. The cache preserves compiled infected code even after source cleanup.
+- **`PROCESSES` matches** — real if the command line contains any IOC; this is an active infection, handle it first.
+- **`GITHUB_SCAN` counts > 0** — real unless the file is a documented scanner. Report repo + path.
 
-### 5.1 tasks.json Dropper
+If you need to look up what a given signature means, read [`references/iocs.md`](references/iocs.md).
 
-Search ALL `.vscode/tasks.json` files within `$SCAN_ROOT`:
+## Step 4: Remediate (only if infections are found)
 
-```bash
-find "$SCAN_ROOT" -name "tasks.json" -path "*/.vscode/*" -not -path "*/node_modules/*"
-```
+In this order:
 
-**Red flags in tasks.json:**
-- `"runOn": "folderOpen"` — executes automatically when VS Code opens the folder
-- `"reveal": "never"` — hides terminal output
-- `"echo": false` — suppresses command echo
-- `"hide": true` — hides from task list
-- Commands referencing: `curl | bash`, `wget | sh`, `.woff2` files, `.bat` files, `node -e`
-- UUID `e9b53a7c-2342-4b15-b02d-bd8b8f6a03f9` (StakingGame template marker)
-- Any Vercel C2 domain reference
+1. **Kill active processes** — `kill -9 <pid>` for any process in `PROCESSES` with IOCs in its args.
+2. **Stop running dev servers** (`next dev`, `vite`, etc.) before clearing caches, or they'll immediately rewrite them.
+3. **Delete build caches** — `.next/`, `.cache/`, `.turbo/`, `.parcel-cache/`, `.vite/` in any directory flagged by `BUILD_CACHES`.
+4. **Clean config files** — remove everything after the trailing-whitespace bomb on the `export` line, and remove any `createRequire` import the malware injected into otherwise-simple ESM configs.
+5. **Delete propagation scripts** — `config.bat`, `temp_auto_push.bat`, `temp_interactive_push.bat` wherever found, plus their entries in `.gitignore`.
+6. **Delete VS Code droppers** — malicious `.vscode/tasks.json` and any fake font/binary payload file (check with `file -b <path>`).
+7. **Clean git hooks** — `.git/hooks/*` and `.husky/*` entries containing `config.bat`, `temp_auto_push`, force-push, or `amend --no-verify`.
+8. **Remove malicious npm packages** — delete from `package.json`, remove the `node_modules` directory, regenerate the lock file.
+9. **Commit and push fixes** to each affected repo (regular push; never `--force`).
+10. **Tell the user to rotate credentials** — any API keys, tokens, SSH keys, or crypto seed phrases accessible from this machine should be considered compromised. Recommend revoking them even if no active exfiltration is visible.
+11. **Tell the user to notify collaborators** — anyone who cloned their repos may be infected.
 
-### 5.2 Fake Binary Files as Payloads
+Do every applicable step automatically; confirm only before destructive actions the user might object to (force-pushes, mass credential rotation).
 
-The dropper can execute disguised files. Check ALL font/binary files within `$SCAN_ROOT`:
+## Step 5: Report
 
-```bash
-find "$SCAN_ROOT" -type f \( -name "*.woff2" -o -name "*.woff" -o -name "*.ttf" -o -name "*.eot" -o -name "*.otf" -o -name "*.ico" -o -name "*.dat" -o -name "*.bin" \) -not -path "*/node_modules/*" -not -path "*/.git/*"
-```
-
-For each file, verify it's actually binary: `file -b <path>`. If it reports "ASCII text", "UTF-8 text", "JavaScript", or "script" — **it's a disguised payload**.
-
-Also check first bytes: if a "font" file starts with spaces (`0x20`) or `global` (`0x676c6f62`), it's malware.
-
-### 5.3 VS Code Settings
-
-**GLOBAL scope only** — check if automatic task execution is enabled:
-
-```bash
-grep -i "task.allowAutomaticTasks" ~/Library/Application\ Support/Code/User/settings.json
-```
-
-If set to `"on"`, VS Code will silently run `folderOpen` tasks without prompting. Consider setting to `"off"`.
-
-## Phase 6: Propagation Artifact Scan
-
-### 6.1 Batch Files
-
-Search for malware propagation scripts within `$SCAN_ROOT`:
-
-```bash
-find "$SCAN_ROOT" -name "temp_auto_push.bat" -o -name "temp_interactive_push.bat" -o -name "config.bat" 2>/dev/null | grep -v node_modules
-```
-
-### 6.2 .gitignore Injection
-
-The malware adds its own files to `.gitignore` to hide them. Check all `.gitignore` files for:
-- `config.bat`
-- `temp_auto_push.bat`
-- `temp_interactive_push.bat`
-
-```bash
-find "$SCAN_ROOT" -name ".gitignore" -not -path "*/node_modules/*" | xargs grep -l "config\.bat\|temp_auto_push\|temp_interactive_push" 2>/dev/null
-```
-
-### 6.3 Git Hooks
-
-Check for infected git hooks that propagate the malware:
-
-```bash
-find "$SCAN_ROOT" -path "*/.git/hooks/*" -type f -not -name "*.sample" | while read f; do
-  if grep -q "config\.bat\|temp_auto\|force.*push\|amend.*no-verify" "$f" 2>/dev/null; then
-    echo "INFECTED HOOK: $f"
-  fi
-done
-```
-
-Also check Husky hooks (`.husky/pre-push`, `.husky/post-commit`, etc.) for similar patterns.
-
-## Phase 7: Malicious npm Package Detection
-
-### 7.1 Known Malicious Packages
-
-Search ALL `node_modules` directories within `$SCAN_ROOT` for these packages:
-
-- `tailwindcss-style-animate`
-- `tailwind-mainanimation`
-- `tailwind-autoanimation`
-- `tailwind-animationbased`
-- `tailwindcss-typography-style`
-- `tailwindcss-style-modify`
-- `tailwindcss-animate-style`
-
-```bash
-for pkg in tailwindcss-style-animate tailwind-mainanimation tailwind-autoanimation tailwind-animationbased tailwindcss-typography-style tailwindcss-style-modify tailwindcss-animate-style; do
-  find "$SCAN_ROOT" -path "*/node_modules/$pkg" -type d 2>/dev/null
-done
-```
-
-### 7.2 Lock File References
-
-Check `package-lock.json`, `yarn.lock`, and `pnpm-lock.yaml` for references to the malicious packages listed above.
-
-### 7.3 Suspicious Lifecycle Scripts
-
-Check for npm packages with suspicious `postinstall`/`preinstall` scripts:
-
-```bash
-find "$SCAN_ROOT" -path "*/node_modules/*/package.json" -maxdepth 5 | xargs grep -l "postinstall.*node -e\|postinstall.*curl\|postinstall.*eval\|preinstall.*node -e" 2>/dev/null
-```
-
-## Phase 8: System Persistence Check
-
-**GLOBAL scope only — skip this phase in local scope.**
-
-### 8.1 macOS
-
-- **LaunchAgents**: `ls -la ~/Library/LaunchAgents/` — check for non-Apple, non-Google entries. Read suspicious plist files with `plutil -p`.
-- **LaunchDaemons**: `ls -la /Library/LaunchDaemons/` — same check.
-- **Crontab**: `crontab -l`
-- **Login Items**: Check System Preferences → General → Login Items.
-
-### 8.2 Linux
-
-- **Crontab**: `crontab -l` and check `/etc/cron.d/`, `/etc/cron.daily/`
-- **Systemd**: `systemctl list-units --type=service --state=running` — look for unfamiliar services
-- **Profile scripts**: Check `~/.bashrc`, `~/.profile`, `~/.bash_profile` for injected lines
-
-### 8.3 All Platforms
-
-- **Shell profiles** (`~/.zshrc`, `~/.bashrc`, `~/.zprofile`, `~/.profile`, `~/.zshenv`): Check for injected `eval`, `curl | bash`, `node -e`, base64-encoded strings, or unfamiliar PATH additions.
-- **Git global config** (`~/.gitconfig`): Check for `core.hooksPath` pointing to a non-standard location, suspicious aliases, or modified credential helpers.
-- **npm/yarn config** (`~/.npmrc`, `~/.yarnrc`, `~/.yarnrc.yml`): Check for modified registry URLs or injected scripts.
-- **SSH config** (`~/.ssh/config`): Check for ProxyCommand injections or unfamiliar hosts.
-
-## Phase 9: GitHub Repository Scan
-
-**GLOBAL scope only — skip in local scope unless user explicitly asks.** Requires `gh` CLI authenticated.
-
-Use the GitHub API to search all repos owned by the authenticated user. Run each search:
-
-```bash
-USER=$(gh api /user --jq '.login')
-
-# Critical payload signatures (0 results expected for clean accounts)
-gh api "/search/code?q=_\$_1e42+user:$USER" --jq '.total_count'
-gh api "/search/code?q=%22global%5B'!'%5D%22+user:$USER+-filename:polinrider-scanner" --jq '.total_count'
-gh api "/search/code?q=%22global%5B'_V'%5D%22+user:$USER" --jq '.total_count'
-gh api "/search/code?q=rmcej+user:$USER+-filename:polinrider-scanner" --jq '.total_count'
-gh api "/search/code?q=%22Cot%253t%3DshtP%22+user:$USER" --jq '.total_count'
-
-# C2 endpoints
-gh api "/search/code?q=%22260120.vercel.app%22+user:$USER" --jq '.total_count'
-gh api "/search/code?q=%22default-configuration.vercel.app%22+user:$USER" --jq '.total_count'
-
-# Propagation artifacts
-gh api "/search/code?q=filename:temp_auto_push.bat+user:$USER" --jq '.total_count'
-gh api "/search/code?q=%22config.bat%22+user:$USER+filename:.gitignore" --jq '.total_count'
-
-# Malware residue
-gh api "/search/code?q=createRequire+user:$USER+filename:postcss.config" --jq '.total_count'
-gh api "/search/code?q=createRequire+user:$USER+filename:next.config" --jq '.total_count'
-gh api "/search/code?q=createRequire+user:$USER+filename:webpack.config" --jq '.total_count'
-
-# VS Code droppers
-gh api "/search/code?q=folderOpen+user:$USER+filename:tasks.json" --jq '.total_count'
-gh api "/search/code?q=%22e9b53a7c-2342-4b15-b02d-bd8b8f6a03f9%22+user:$USER" --jq '.total_count'
-
-# Malicious packages
-gh api "/search/code?q=%22tailwindcss-style-animate%22+user:$USER" --jq '.total_count'
-gh api "/search/code?q=%22tailwind-mainanimation%22+user:$USER" --jq '.total_count'
-```
-
-**Any non-zero result (except scanner scripts) means active infection.** Report the file path and repo.
-
-**NOTE:** GitHub code search only indexes the default branch. For repos with multiple branches, clone locally and scan with `git log --all --diff-filter=A -- "*.bat"` to check for `temp_auto_push.bat` in history.
-
-## Phase 10: Creative / Novel Detection
-
-These checks go beyond documented IOCs to catch variants or undocumented behaviors.
-
-### 10.1 Obfuscation Pattern Detection
-
-Search for generic obfuscation indicators in config files within `$SCAN_ROOT` (not just known signatures):
-
-```bash
-find "$SCAN_ROOT" \( -name "*.config.*" -o -name ".eslintrc*" \) \
-  -not -path "*/node_modules/*" -not -path "*/.git/*" | \
-  xargs grep -l "eval(\|new Function(\|child_process\|spawn(\|exec(" 2>/dev/null
-```
-
-### 10.2 Binary Masquerading
-
-Check ALL non-code files within `$SCAN_ROOT` for hidden JavaScript:
-
-```bash
-find "$SCAN_ROOT" -type f \( -name "*.woff2" -o -name "*.woff" -o -name "*.ttf" -o -name "*.eot" -o -name "*.png" -o -name "*.jpg" -o -name "*.ico" -o -name "*.dat" -o -name "*.bin" -o -name "*.dll" -o -name "*.so" \) -not -path "*/node_modules/*" -not -path "*/.git/*" -size -1M | while read f; do
-  filetype=$(file -b "$f")
-  if echo "$filetype" | grep -qi "text\|ascii\|javascript\|utf-8"; then
-    echo "FAKE BINARY: $f ($filetype)"
-  fi
-done
-```
-
-### 10.3 Recently Modified Config Files
-
-Check for config files modified in the last 7 days that weren't part of a git commit:
-
-```bash
-find "$SCAN_ROOT" -name "*.config.*" -mtime -7 -not -path "*/node_modules/*" -not -path "*/.git/*" -not -path "*/.next/*"
-```
-
-### 10.4 Tampered node_modules
-
-The malware can modify files inside `node_modules` directly. Check integrity of critical packages:
-
-```bash
-cd <repo> && npm ls --all 2>&1 | grep "WARN\|ERR\|invalid"
-```
-
-Or for a specific package, compare its file hash to the published version:
-
-```bash
-npm pack <package-name> --dry-run 2>/dev/null
-```
-
-### 10.5 Git Reflog Anomalies
-
-Check for suspicious `amend` entries in the reflog (the malware amends commits to inject its payload):
-
-```bash
-find "$SCAN_ROOT" -maxdepth 2 -name ".git" -type d | while read g; do
-  repo=$(dirname "$g")
-  amends=$(cd "$repo" && git reflog 2>/dev/null | grep -c "amend")
-  if [ "$amends" -gt 0 ]; then
-    echo "$(basename $repo): $amends amend entries"
-  fi
-done
-```
-
-### 10.6 Unexpected Detached Processes
-
-Beyond `node -e`, check for any process spawned from project directories that's now orphaned:
-
-```bash
-lsof +D "$SCAN_ROOT" 2>/dev/null | grep -v "Code\|claude\|git\|node_modules" | awk '{print $1, $2, $9}' | sort -u
-```
-
-### 10.7 Environment Variable Leaks
-
-The malware sets `LAST_COMMIT_DATE`, `LAST_COMMIT_TIME`, etc. Check if these persist:
-
-```bash
-env | grep -i "LAST_COMMIT\|USER_NAME\|USER_EMAIL\|CURRENT_BRANCH"
-```
-
-### 10.8 Cryptocurrency Wallet Exposure
-
-**GLOBAL scope only.** If you have any crypto wallets on this machine, check for unauthorized access:
-- Check browser extension permissions for wallet extensions (MetaMask, Phantom, etc.)
-- Review recent transactions on any wallets whose keys were accessible from this machine
-- Rotate all private keys and seed phrases stored on or accessible from this machine
-- Check `~/.config/`, `~/Library/Application Support/` for wallet data files that may have been read
-
-## Remediation Checklist
-
-If infections are found:
-
-1. **Kill all malicious processes** (`kill -9`)
-2. **Delete build caches** (`.next/`, `.cache/`, `.turbo/`, `.parcel-cache/`, `.vite/`)
-3. **Clean config files** — remove the payload (everything after trailing spaces on the export line) AND remove `createRequire` imports
-4. **Clean .gitignore** — remove `config.bat`, `temp_auto_push.bat`, `temp_interactive_push.bat` entries
-5. **Delete propagation scripts** — `config.bat`, `temp_auto_push.bat`, `temp_interactive_push.bat`
-6. **Delete VS Code droppers** — malicious `.vscode/tasks.json` and any fake font/binary payload files
-7. **Delete malicious npm packages** — remove from `package.json`, delete from `node_modules`, regenerate lock file
-8. **Clean git hooks** — check `.git/hooks/` and `.husky/` for infected hooks
-9. **Commit and push fixes** to all affected repos
-10. **Rotate credentials** — any API keys, tokens, wallet keys, or secrets on this machine should be considered compromised
-11. **Notify collaborators** — anyone who has cloned your repos may be infected
-
-## Output Format
-
-Present results as:
+Emit this structure (fill every section, even if empty):
 
 ```
-## Scan Results (scope: LOCAL | GLOBAL)
+## PolinRider Scan Results (scope: LOCAL|GLOBAL, root: <path>)
 
-### Official scanner (OSM polinrider-scanner.sh)
-<exit code, summary of findings, or "skipped — offline">
+### Step 1 — Official OSM scanner
+<exit status and any findings from the upstream script, or "skipped (offline)">
 
-### Active Threats
-| Type | Location | Status |
+### Step 2 — Extended checks
+
+**Active threats**
+| Type | Location | Action taken |
 |---|---|---|
 
-### Infections Found
+**Infections found**
 | Category | File/Location | Details | Remediated? |
 |---|---|---|---|
 
-### Clean Checks
-- [x] No malicious processes
-- [x] No C2 connections
-- [x] No payload signatures in source files
-- [x] No infected build caches
-- [x] No VS Code droppers
-- [x] No fake binary files
-- [x] No propagation scripts
-- [x] No .gitignore injection
-- [x] No infected git hooks
-- [x] No malicious npm packages
-- [x] No system persistence (global scope only)
-- [x] No shell profile injection (global scope only)
-- [x] GitHub repos clean (global scope only)
+**Clean checks**
+- [ ] Processes
+- [ ] C2 network connections
+- [ ] Source signatures
+- [ ] Config files
+- [ ] Build caches
+- [ ] VS Code droppers
+- [ ] Fake binaries
+- [ ] Propagation scripts / .gitignore / git hooks
+- [ ] npm packages
+- [ ] Obfuscation heuristics
+- [ ] System persistence (global only)
+- [ ] GitHub repos (global only)
 ```
+
+If anything was remediated, end with a short action list for the user: credentials to rotate, collaborators to notify, repos that still need a push.

--- a/skills/polinrider-scan/references/iocs.md
+++ b/skills/polinrider-scan/references/iocs.md
@@ -1,0 +1,77 @@
+# PolinRider IOCs
+
+Reference list of known indicators of compromise. Consult this file when interpreting ambiguous scanner output or when triaging a potential novel variant.
+
+## Obfuscation signatures
+
+### Original variant
+| Signature | Meaning |
+|---|---|
+| `rmcej%otb%` | Obfuscation marker |
+| `_$_1e42` | Decoder function name |
+| `2857687` | Shuffle seed (layer 1) |
+| `2667686` | Shuffle seed (layer 2) |
+| `global['!']` | Global injection marker |
+| `global['r'] = require` | Require hijack |
+| `global['m'] = module` | Module hijack |
+
+### Rotated variant (April 2026)
+| Signature | Meaning |
+|---|---|
+| `Cot%3t=shtP` | Rotated obfuscation marker |
+| `function MDy` / `var MDy=` | Rotated decoder function |
+| `1111436` | Rotated shuffle seed (layer 1) |
+| `3896884` | Rotated shuffle seed (layer 2) |
+| `global['_V']` | Rotated global injection (tags `8-st1` through `8-st59`) |
+
+## XOR keys
+| Key | Role |
+|---|---|
+| ``2[gWfGj;<:-93Z^C`` | Primary XOR decryption key |
+| ``m6:tTh^D)cBz?NM]`` | Secondary XOR decryption key |
+
+## C2 endpoints (HTTP)
+- `260120.vercel.app`
+- `default-configuration.vercel.app`
+- `vscode-settings-bootstrap.vercel.app`
+- `vscode-settings-config.vercel.app`
+- `vscode-bootstrapper.vercel.app`
+- `vscode-load-config.vercel.app`
+
+## C2 endpoints (blockchain dead-drop)
+- `api.trongrid.io`
+- `fullnode.mainnet.aptoslabs.com`
+- `bsc-dataseed.binance.org`
+- `bsc-rpc.publicnode.com`
+
+## Blockchain addresses
+| Chain | Address |
+|---|---|
+| TRON | `TMfKQEd7TJJa5xNZJZ2Lep838vrzrs7mAP` |
+| TRON | `TXfxHUet9pJVU1BgVkBAbrES4YUc1nGzcG` |
+| Aptos | `0xbe037400670fbf1c32364f762975908dc43eeb38759263e7dfcdabc76380811e` |
+| Aptos | `0x3f0e5781d0855fb460661ac63257376db1941b2bb522499e4757ecb3ebd5dce3` |
+
+## Malicious npm packages
+- `tailwindcss-style-animate`
+- `tailwind-mainanimation`
+- `tailwind-autoanimation`
+- `tailwind-animationbased`
+- `tailwindcss-typography-style`
+- `tailwindcss-style-modify`
+- `tailwindcss-animate-style`
+
+## Propagation artifacts
+- `temp_auto_push.bat`
+- `temp_interactive_push.bat`
+- `config.bat`
+
+## VS Code dropper markers
+- `"runOn": "folderOpen"` in `.vscode/tasks.json` combined with hidden-output flags (`reveal: never`, `echo: false`, `hide: true`)
+- Template UUID: `e9b53a7c-2342-4b15-b02d-bd8b8f6a03f9` (StakingGame)
+- Any of the Vercel C2 domains above referenced from a task
+- Disguised font/binary files (`.woff2`, `.ttf`, `.bin`) whose first bytes are ASCII space (`0x20`) or `global` (`0x676c6f62`)
+
+## Config file hiding technique
+
+The payload is appended to `module.exports = ...` (or equivalent) after **hundreds of trailing spaces** on the same line. Editors render the line as normal; the payload is off-screen. The presence of `createRequire` in a simple ESM config file (postcss, tailwind, etc.) is residue left behind after a partial cleanup.

--- a/skills/polinrider-scan/scripts/scan.sh
+++ b/skills/polinrider-scan/scripts/scan.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# PolinRider malware scanner
+#
+# Step 1 runs the official OSM scanner from OpenSourceMalware/PolinRider.
+# Step 2 runs extended IOC/variant checks that complement the upstream scanner.
+#
+# Usage: scan.sh <scope> [scan_root]
+#   scope      "local" or "global"
+#   scan_root  absolute path (default: cwd for local, $HOME for global)
+#
+# Output is organized as == SECTION == blocks so the calling agent can parse
+# findings cleanly. Exit code is always 0; detection state lives in the output.
+
+set -u
+
+SCOPE="${1:-}"
+if [[ "$SCOPE" != "local" && "$SCOPE" != "global" ]]; then
+  echo "usage: scan.sh <local|global> [scan_root]" >&2
+  exit 2
+fi
+
+SCAN_ROOT="${2:-}"
+if [[ -z "$SCAN_ROOT" ]]; then
+  if [[ "$SCOPE" == "local" ]]; then SCAN_ROOT="$PWD"; else SCAN_ROOT="$HOME"; fi
+fi
+
+EXCLUDES=( -not -path "*/node_modules/*" -not -path "*/.git/*" -not -path "*/.next/*" -not -path "*/dist/*" -not -path "*/build/*" )
+CODE_NAMES=( -name "*.js" -o -name "*.mjs" -o -name "*.cjs" -o -name "*.ts" -o -name "*.tsx" -o -name "*.json" -o -name "*.bat" -o -name "*.sh" )
+
+echo "== META =="
+echo "scope=$SCOPE"
+echo "scan_root=$SCAN_ROOT"
+echo "host=$(uname -s) $(uname -r)"
+echo "started=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo
+
+# ---------- Step 1: Official OSM scanner ----------
+echo "== OSM_SCANNER =="
+OSM_URL="https://raw.githubusercontent.com/OpenSourceMalware/PolinRider/main/polinrider-scanner.sh"
+OSM_TMP="$(mktemp -t polinrider-scanner.XXXXXX.sh)"
+if curl -fsSL --max-time 30 "$OSM_URL" -o "$OSM_TMP" 2>/dev/null; then
+  echo "downloaded: $OSM_TMP"
+  # Best-effort: pass scan root if the scanner accepts it, otherwise run with no args.
+  bash "$OSM_TMP" "$SCAN_ROOT" 2>&1 || bash "$OSM_TMP" 2>&1
+else
+  echo "skipped: could not download $OSM_URL"
+fi
+rm -f "$OSM_TMP"
+echo
+
+# ---------- Step 2a: Active threats ----------
+echo "== PROCESSES =="
+ps aux 2>/dev/null | grep -E "node -e|global\['!'\]|global\['_V'\]|_\\\$_1e42|MDy|rmcej|2857687|1111436" | grep -v grep || echo "none"
+echo
+echo "-- reparented node (ppid=1) --"
+ps -eo pid,ppid,comm,args 2>/dev/null | awk '$2 == 1 && /node/ {print}' || echo "none"
+echo
+
+echo "== NETWORK_C2 =="
+C2_DOMAINS=(
+  260120.vercel.app
+  default-configuration.vercel.app
+  vscode-settings-bootstrap.vercel.app
+  vscode-settings-config.vercel.app
+  vscode-bootstrapper.vercel.app
+  vscode-load-config.vercel.app
+  api.trongrid.io
+  fullnode.mainnet.aptoslabs.com
+  bsc-dataseed.binance.org
+  bsc-rpc.publicnode.com
+)
+if command -v lsof >/dev/null 2>&1; then
+  lsof -i -n -P 2>/dev/null | grep -i "node" | grep -v localhost || echo "no node network connections"
+else
+  echo "lsof unavailable"
+fi
+echo "-- known C2 domains (informational) --"
+printf '%s\n' "${C2_DOMAINS[@]}"
+echo
+
+# ---------- Step 2b: Payload signatures in source ----------
+echo "== SIGNATURES =="
+SIGS=(
+  "rmcej%otb%"
+  "_\$_1e42"
+  "2857687"
+  "2667686"
+  "global\['!'\]"
+  "global\['r'\] = require"
+  "global\['m'\] = module"
+  "Cot%3t=shtP"
+  "function MDy"
+  "var MDy="
+  "1111436"
+  "3896884"
+  "global\['_V'\]"
+  "2\[gWfGj;<:-93Z\^C"
+  "m6:tTh\^D)cBz?NM\]"
+  "TMfKQEd7TJJa5xNZJZ2Lep838vrzrs7mAP"
+  "TXfxHUet9pJVU1BgVkBAbrES4YUc1nGzcG"
+  "0xbe037400670fbf1c32364f762975908dc43eeb38759263e7dfcdabc76380811e"
+  "0x3f0e5781d0855fb460661ac63257376db1941b2bb522499e4757ecb3ebd5dce3"
+)
+PATTERN=$(IFS='|'; echo "${SIGS[*]}")
+find "$SCAN_ROOT" -type f \( "${CODE_NAMES[@]}" \) "${EXCLUDES[@]}" \
+  ! -name "polinrider-scanner*" ! -name "scan.sh" ! -name "SKILL.md" ! -name "iocs.md" -print0 2>/dev/null \
+  | xargs -0 grep -lE "$PATTERN" 2>/dev/null || echo "none"
+echo
+
+# ---------- Step 2c: Config file infection ----------
+echo "== CONFIG_FILES =="
+CONFIG_GLOBS=(
+  "postcss.config.*" "tailwind.config.*" "eslint.config.*" "next.config.*"
+  "vite.config.*" "webpack.config.*" "astro.config.*" "gridsome.config.*"
+  "vue.config.*" "rollup.config.*" "babel.config.*" "truffle.js" ".eslintrc*"
+)
+for glob in "${CONFIG_GLOBS[@]}"; do
+  find "$SCAN_ROOT" -type f -name "$glob" "${EXCLUDES[@]}" -print 2>/dev/null
+done | while read -r f; do
+  [[ -z "$f" ]] && continue
+  maxlen=$(awk '{ if(length > max) max=length } END { print max+0 }' "$f" 2>/dev/null)
+  has_long_ws=$(grep -cE ' {50,}' "$f" 2>/dev/null || echo 0)
+  has_sig=$(grep -cE "global\['!'\]|global\['_V'\]|_\\\$_1e42|function MDy|rmcej" "$f" 2>/dev/null || echo 0)
+  has_cr=$(grep -cE "createRequire" "$f" 2>/dev/null || echo 0)
+  if (( maxlen > 200 )) || (( has_long_ws > 0 )) || (( has_sig > 0 )) || (( has_cr > 0 )); then
+    echo "SUSPECT: $f (max_line=$maxlen, long_ws=$has_long_ws, sig=$has_sig, createRequire=$has_cr)"
+  fi
+done
+echo
+
+# ---------- Step 2d: Build cache infection ----------
+echo "== BUILD_CACHES =="
+for cache in .next .cache .turbo .parcel-cache .vite; do
+  find "$SCAN_ROOT" -type d -name "$cache" -not -path "*/node_modules/*" 2>/dev/null | while read -r d; do
+    hit=$(grep -rlE "global\['!'\]|_\\\$_1e42|rmcej|global\['_V'\]|MDy" "$d/" 2>/dev/null | head -3)
+    [[ -n "$hit" ]] && echo "INFECTED: $hit"
+  done
+done || true
+echo
+
+# ---------- Step 2e: VS Code droppers ----------
+echo "== VSCODE_DROPPERS =="
+find "$SCAN_ROOT" -name "tasks.json" -path "*/.vscode/*" -not -path "*/node_modules/*" -print 2>/dev/null | while read -r f; do
+  if grep -qE "folderOpen|e9b53a7c-2342-4b15-b02d-bd8b8f6a03f9|\.woff2|\.bat|node -e|curl.*\|.*bash|wget.*\|.*sh" "$f" 2>/dev/null; then
+    echo "SUSPECT: $f"
+  fi
+done
+echo
+
+echo "== FAKE_BINARIES =="
+find "$SCAN_ROOT" -type f \( -name "*.woff2" -o -name "*.woff" -o -name "*.ttf" -o -name "*.eot" -o -name "*.otf" -o -name "*.ico" -o -name "*.dat" -o -name "*.bin" \) "${EXCLUDES[@]}" -size -1M -print 2>/dev/null | while read -r f; do
+  ft=$(file -b "$f" 2>/dev/null)
+  if echo "$ft" | grep -qiE "text|ascii|javascript|utf-8|script"; then
+    echo "FAKE: $f ($ft)"
+  fi
+done
+echo
+
+# ---------- Step 2f: Propagation artifacts ----------
+echo "== PROPAGATION_ARTIFACTS =="
+find "$SCAN_ROOT" \( -name "temp_auto_push.bat" -o -name "temp_interactive_push.bat" -o -name "config.bat" \) -not -path "*/node_modules/*" -print 2>/dev/null || echo "none"
+echo "-- .gitignore injection --"
+find "$SCAN_ROOT" -name ".gitignore" -not -path "*/node_modules/*" -print 2>/dev/null | xargs grep -lE "config\.bat|temp_auto_push|temp_interactive_push" 2>/dev/null || echo "none"
+echo "-- infected git hooks --"
+find "$SCAN_ROOT" -path "*/.git/hooks/*" -type f -not -name "*.sample" 2>/dev/null | while read -r f; do
+  grep -qE "config\.bat|temp_auto|force.*push|amend.*no-verify" "$f" 2>/dev/null && echo "HOOK: $f"
+done
+find "$SCAN_ROOT" -path "*/.husky/*" -type f 2>/dev/null | while read -r f; do
+  grep -qE "config\.bat|temp_auto|force.*push|amend.*no-verify" "$f" 2>/dev/null && echo "HUSKY: $f"
+done
+echo
+
+# ---------- Step 2g: Malicious npm packages ----------
+echo "== NPM_PACKAGES =="
+BAD_PKGS=(
+  tailwindcss-style-animate tailwind-mainanimation tailwind-autoanimation
+  tailwind-animationbased tailwindcss-typography-style tailwindcss-style-modify
+  tailwindcss-animate-style
+)
+for pkg in "${BAD_PKGS[@]}"; do
+  find "$SCAN_ROOT" -path "*/node_modules/$pkg" -type d 2>/dev/null
+done || true
+echo "-- suspicious lifecycle scripts --"
+find "$SCAN_ROOT" -path "*/node_modules/*/package.json" -maxdepth 7 2>/dev/null | xargs grep -lE "(postinstall|preinstall).*(node -e|curl|eval)" 2>/dev/null || echo "none"
+echo
+
+# ---------- Step 2h: Obfuscation / novel variants ----------
+echo "== OBFUSCATION_HEURISTICS =="
+find "$SCAN_ROOT" \( -name "*.config.*" -o -name ".eslintrc*" \) "${EXCLUDES[@]}" -print 2>/dev/null | xargs grep -lE "eval\(|new Function\(|child_process|spawn\(|exec\(" 2>/dev/null || echo "none"
+echo "-- recently modified configs (last 7 days) --"
+find "$SCAN_ROOT" -name "*.config.*" -mtime -7 "${EXCLUDES[@]}" -print 2>/dev/null || echo "none"
+echo
+
+# ---------- Step 2i: Global-only phases ----------
+if [[ "$SCOPE" == "global" ]]; then
+  echo "== PERSISTENCE =="
+  case "$(uname -s)" in
+    Darwin)
+      echo "-- ~/Library/LaunchAgents --"
+      ls -la "$HOME/Library/LaunchAgents/" 2>/dev/null | tail -n +2 || echo "none"
+      echo "-- /Library/LaunchDaemons --"
+      ls -la "/Library/LaunchDaemons/" 2>/dev/null | tail -n +2 || echo "none"
+      ;;
+    Linux)
+      echo "-- /etc/cron.d --"
+      ls -la /etc/cron.d 2>/dev/null || echo "none"
+      echo "-- running systemd services --"
+      systemctl list-units --type=service --state=running --no-pager 2>/dev/null | head -40 || echo "n/a"
+      ;;
+  esac
+  echo "-- crontab --"
+  crontab -l 2>/dev/null || echo "none"
+  echo "-- shell profiles --"
+  for rc in ~/.zshrc ~/.bashrc ~/.zprofile ~/.profile ~/.bash_profile ~/.zshenv; do
+    [[ -f "$rc" ]] || continue
+    grep -nE "eval |curl .*\| *bash|wget .*\| *sh|node -e|base64 -d" "$rc" 2>/dev/null \
+      | sed "s|^|$rc:|" || true
+  done
+  echo "-- git/npm/ssh config --"
+  grep -nE "core\.hooksPath|credentialHelper" "$HOME/.gitconfig" 2>/dev/null | sed "s|^|~/.gitconfig:|" || true
+  grep -nE "registry|ProxyCommand" "$HOME/.npmrc" "$HOME/.yarnrc" "$HOME/.ssh/config" 2>/dev/null | head -40 || true
+  echo "-- env leaks --"
+  env | grep -iE "LAST_COMMIT|USER_NAME|USER_EMAIL|CURRENT_BRANCH" || echo "none"
+  echo
+
+  echo "== GITHUB_SCAN =="
+  if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+    USER=$(gh api /user --jq '.login' 2>/dev/null)
+    echo "user=$USER"
+    for q in \
+      "_\$_1e42+user:$USER" \
+      "%22global%5B'!'%5D%22+user:$USER+-filename:polinrider-scanner" \
+      "%22global%5B'_V'%5D%22+user:$USER" \
+      "rmcej+user:$USER+-filename:polinrider-scanner" \
+      "%22Cot%253t%3DshtP%22+user:$USER" \
+      "%22260120.vercel.app%22+user:$USER" \
+      "filename:temp_auto_push.bat+user:$USER" \
+      "createRequire+user:$USER+filename:postcss.config" \
+      "folderOpen+user:$USER+filename:tasks.json" \
+      "%22e9b53a7c-2342-4b15-b02d-bd8b8f6a03f9%22+user:$USER" \
+      "%22tailwindcss-style-animate%22+user:$USER"
+    do
+      count=$(gh api "/search/code?q=$q" --jq '.total_count' 2>/dev/null || echo "?")
+      printf '%s\t%s\n' "$count" "$q"
+    done
+  else
+    echo "skipped: gh not installed or not authenticated"
+  fi
+  echo
+fi
+
+echo "== DONE =="
+echo "finished=$(date -u +%Y-%m-%dT%H:%M:%SZ)"


### PR DESCRIPTION
Follow-up to #2. Two changes:

## Summary
- **Phase 0** — the skill now first downloads and runs the official [`polinrider-scanner.sh`](https://github.com/OpenSourceMalware/PolinRider/blob/main/polinrider-scanner.sh) from OpenSourceMalware (the authoritative IOC scanner), then layers extended AI-driven checks on top
- **Spec restructure** — aligned with [`anthropics/skills/skill-creator`](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md) conventions:
  - All deterministic detection logic moved into [`scripts/scan.sh`](./skills/polinrider-scan/scripts/scan.sh), which emits `== SECTION ==` blocks
  - IOC catalogue split out into [`references/iocs.md`](./skills/polinrider-scan/references/iocs.md)
  - [`SKILL.md`](./skills/polinrider-scan/SKILL.md) slimmed from ~500 lines to ~100: just scope detection, script invocation, interpretation, remediation, and report format (with a "pushier" description per skill-creator guidance)

## Test plan
- [ ] Install via `npx skills add finom/finom --skill polinrider-scan -g` and confirm the restructured layout resolves
- [ ] Run `/polinrider-scan` globally — confirm `scripts/scan.sh global $HOME` runs, OSM scanner downloads, all sections populate
- [ ] Run `/polinrider-scan` from inside a project with `-skill polinrider-scan` installed locally — confirm it defaults to local scope and skips `PERSISTENCE` / `GITHUB_SCAN` sections
- [ ] Pass explicit path arg (e.g., `/polinrider-scan ~/Work/some-repo`) — confirm override works